### PR TITLE
Update Checkout version in example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dequelabs/axe-linter-action@v1
         with:
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}


### PR DESCRIPTION
Matches what the Axe Linter Docs suggests (and checkout@v3 is deprecated).