### PR TITLE
feat: add filename and line number to error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43062,13 +43062,16 @@ ${pendingInterceptorsFormatter.format(pending)}
             totalErrors += errors.length
             // Report errors using GitHub annotations
             for (const error of errors) {
-              core.error(`${error.ruleId} - ${error.description}`, {
-                file,
-                startLine: error.lineNumber,
-                startColumn: error.column,
-                endColumn: error.endColumn,
-                title: 'Axe Linter'
-              })
+              core.error(
+                `${file}:${error.lineNumber} - ${error.ruleId} - ${error.description}`,
+                {
+                  file,
+                  startLine: error.lineNumber,
+                  startColumn: error.column,
+                  endColumn: error.endColumn,
+                  title: 'Axe Linter'
+                }
+              )
             }
           }
           core.debug(

--- a/src/linter.test.ts
+++ b/src/linter.test.ts
@@ -113,7 +113,7 @@ describe('linter', () => {
 
       // Verify error reporting
       assert.isTrue(
-        errorStub.calledWith('test-rule-1 - Test error 1', {
+        errorStub.calledWith('test.js:1 - test-rule-1 - Test error 1', {
           file: 'test.js',
           startLine: 1,
           startColumn: 1,
@@ -124,7 +124,7 @@ describe('linter', () => {
       )
 
       assert.isTrue(
-        errorStub.calledWith('test-rule-2 - Test error 2', {
+        errorStub.calledWith('test.html:1 - test-rule-2 - Test error 2', {
           file: 'test.html',
           startLine: 1,
           startColumn: 1,

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -55,13 +55,16 @@ export async function lintFiles(
 
     // Report errors using GitHub annotations
     for (const error of errors) {
-      core.error(`${error.ruleId} - ${error.description}`, {
-        file,
-        startLine: error.lineNumber,
-        startColumn: error.column,
-        endColumn: error.endColumn,
-        title: 'Axe Linter'
-      })
+      core.error(
+        `${file}:${error.lineNumber} - ${error.ruleId} - ${error.description}`,
+        {
+          file,
+          startLine: error.lineNumber,
+          startColumn: error.column,
+          endColumn: error.endColumn,
+          title: 'Axe Linter'
+        }
+      )
     }
   }
 


### PR DESCRIPTION
This adds the file and line number in the actions tab when viewing the run so that the user does not just see the error and this gives additional context. 

Before:
![image](https://github.com/user-attachments/assets/885115ce-02ba-47b1-9ab5-ba6018dbf907)

After:
![image](https://github.com/user-attachments/assets/1cfdcc5c-1789-4e27-8f2b-82706038d833)

qa notes: when qa'ing this we should make sure that files and lines exist in the error output