### PR TITLE
feat: add summary to action job

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43079,17 +43079,15 @@ ${pendingInterceptorsFormatter.format(pending)}
               // Add file heading
               core.summary
                 .addHeading(
-                  `Error${(0, utils_1.pluralize)(errors.length)} in ${file}:`,
+                  `❌ Error${(0, utils_1.pluralize)(errors.length)} in ${file}:`,
                   2
                 )
-                .addRaw('<span style="color: red">', true)
                 .addList(
                   errors.map(
                     (error) =>
-                      `Line ${error.line}: ${error.ruleId} - ${error.description}`
+                      `🔴 Line ${error.line}: ${error.ruleId} - ${error.description}`
                   )
                 )
-                .addRaw('</span>', true)
                 .addBreak()
               // Create GitHub annotations
               for (const error of errors) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -43091,13 +43091,16 @@ ${pendingInterceptorsFormatter.format(pending)}
                 .addBreak()
               // Create GitHub annotations
               for (const error of errors) {
-                core.error(`${error.ruleId} - ${error.description}`, {
-                  file,
-                  startLine: error.line,
-                  startColumn: error.column,
-                  endColumn: error.endColumn,
-                  title: 'Axe Linter'
-                })
+                core.error(
+                  `${file}:${error.line} - ${error.ruleId} - ${error.description}`,
+                  {
+                    file,
+                    startLine: error.line,
+                    startColumn: error.column,
+                    endColumn: error.endColumn,
+                    title: 'Axe Linter'
+                  }
+                )
               }
             }
           }

--- a/dist/index.js
+++ b/dist/index.js
@@ -43021,7 +43021,7 @@ ${pendingInterceptorsFormatter.format(pending)}
       function lintFiles(files, apiKey, axeLinterUrl, linterConfig) {
         return __awaiter(this, void 0, void 0, function* () {
           let totalErrors = 0
-          let fileErrors = {}
+          const fileErrors = {}
           for (const file of files) {
             const fileContents = (0, fs_1.readFileSync)(file, 'utf8')
             // Skip empty files
@@ -43078,13 +43078,18 @@ ${pendingInterceptorsFormatter.format(pending)}
             if (errors.length > 0) {
               // Add file heading
               core.summary
-                .addHeading(`Errors in ${file}:`, 3)
+                .addHeading(
+                  `Error${(0, utils_1.pluralize)(errors.length)} in ${file}:`,
+                  2
+                )
+                .addRaw('<span style="color: red">', true)
                 .addList(
                   errors.map(
                     (error) =>
                       `Line ${error.line}: ${error.ruleId} - ${error.description}`
                   )
                 )
+                .addRaw('</span>', true)
                 .addBreak()
               // Create GitHub annotations
               for (const error of errors) {

--- a/src/linter.test.ts
+++ b/src/linter.test.ts
@@ -452,21 +452,22 @@ describe('linter', () => {
 
       // Verify file sections
       assert.isTrue(
-        summaryStub.addHeading.calledWith('Error in app.js:', 3),
+        summaryStub.addHeading.calledWith('❌ Error in app.js:', 2),
         'Should add app.js section'
       )
+
       assert.isTrue(
-        summaryStub.addHeading.calledWith('Errors in index.html:', 3),
+        summaryStub.addHeading.calledWith('❌ Errors in index.html:', 2),
         'Should add index.html section'
       )
 
       // Verify error lists
       const appJsErrors = [
-        'Line 1: click-handler - Click handler should have keyboard equivalent'
+        '🔴 Line 1: click-handler - Click handler should have keyboard equivalent'
       ]
       const indexHtmlErrors = [
-        'Line 1: color-contrast - Element has insufficient color contrast',
-        'Line 1: aria-label - Element should have aria-label'
+        '🔴 Line 1: color-contrast - Element has insufficient color contrast',
+        '🔴 Line 1: aria-label - Element should have aria-label'
       ]
 
       assert.isTrue(

--- a/src/linter.test.ts
+++ b/src/linter.test.ts
@@ -12,6 +12,7 @@ describe('linter', () => {
   let sandbox: sinon.SinonSandbox
   let errorStub: sinon.SinonStub
   let debugStub: sinon.SinonStub
+  let summaryStub: any
   let readFileStub: sinon.SinonStub
   let fetchStub: sinon.SinonStub
 
@@ -21,6 +22,16 @@ describe('linter', () => {
     // Stub core functions
     errorStub = sandbox.stub(core, 'error')
     debugStub = sandbox.stub(core, 'debug')
+
+    // Create summary stub with chainable methods
+    summaryStub = {
+      addHeading: sandbox.stub().returnsThis(),
+      addBreak: sandbox.stub().returnsThis(),
+      addList: sandbox.stub().returnsThis(),
+      addRaw: sandbox.stub().returnsThis(),
+      write: sandbox.stub().resolves()
+    }
+    sandbox.stub(core, 'summary').value(summaryStub)
 
     // Stub file system
     readFileStub = sandbox.stub()
@@ -363,6 +374,173 @@ describe('linter', () => {
         assert.include(error.message, 'Invalid config')
         assert.isTrue(scope.isDone(), 'API request should be made')
       }
+    })
+
+    it('should create summary with grouped errors', async () => {
+      const files = ['app.js', 'index.html']
+      const apiKey = 'test-key'
+      const axeLinterUrl = 'https://test-linter.com'
+      const linterConfig = {}
+
+      // Setup file reads
+      readFileStub.withArgs('app.js', 'utf8').returns('const x = 1;')
+      readFileStub.withArgs('index.html', 'utf8').returns('<div>test</div>')
+
+      // Mock API responses
+      nock(axeLinterUrl)
+        .post('/lint-source', {
+          source: 'const x = 1;',
+          filename: 'app.js',
+          config: linterConfig
+        })
+        .reply(200, {
+          report: {
+            errors: [
+              {
+                ruleId: 'click-handler',
+                lineNumber: 1,
+                column: 1,
+                endColumn: 10,
+                description: 'Click handler should have keyboard equivalent'
+              }
+            ]
+          }
+        })
+
+      nock(axeLinterUrl)
+        .post('/lint-source', {
+          source: '<div>test</div>',
+          filename: 'index.html',
+          config: linterConfig
+        })
+        .reply(200, {
+          report: {
+            errors: [
+              {
+                ruleId: 'color-contrast',
+                lineNumber: 1,
+                column: 1,
+                endColumn: 15,
+                description: 'Element has insufficient color contrast'
+              },
+              {
+                ruleId: 'aria-label',
+                lineNumber: 1,
+                column: 1,
+                endColumn: 15,
+                description: 'Element should have aria-label'
+              }
+            ]
+          }
+        })
+
+      const errorCount = await lintFiles(
+        files,
+        apiKey,
+        axeLinterUrl,
+        linterConfig
+      )
+
+      // Verify error count
+      assert.equal(errorCount, 3, 'Should return correct total error count')
+
+      // Verify summary creation
+      assert.isTrue(
+        summaryStub.addHeading.calledWith('Accessibility Linting Results'),
+        'Should add main heading'
+      )
+
+      // Verify file sections
+      assert.isTrue(
+        summaryStub.addHeading.calledWith('Error in app.js:', 3),
+        'Should add app.js section'
+      )
+      assert.isTrue(
+        summaryStub.addHeading.calledWith('Errors in index.html:', 3),
+        'Should add index.html section'
+      )
+
+      // Verify error lists
+      const appJsErrors = [
+        'Line 1: click-handler - Click handler should have keyboard equivalent'
+      ]
+      const indexHtmlErrors = [
+        'Line 1: color-contrast - Element has insufficient color contrast',
+        'Line 1: aria-label - Element should have aria-label'
+      ]
+
+      assert.isTrue(
+        summaryStub.addList.calledWith(appJsErrors),
+        'Should add app.js errors to list'
+      )
+      assert.isTrue(
+        summaryStub.addList.calledWith(indexHtmlErrors),
+        'Should add index.html errors to list'
+      )
+
+      // Verify footer
+      assert.isTrue(
+        summaryStub.addRaw.calledWith('Found 3 accessibility issues'),
+        'Should add correct error count to summary'
+      )
+
+      // Verify GitHub annotations
+      assert.equal(
+        errorStub.callCount,
+        3,
+        'Should create three error annotations'
+      )
+      assert.isTrue(
+        errorStub.calledWith(
+          'click-handler - Click handler should have keyboard equivalent',
+          {
+            file: 'app.js',
+            startLine: 1,
+            startColumn: 1,
+            endColumn: 10,
+            title: 'Axe Linter'
+          }
+        ),
+        'Should create correct annotation for app.js'
+      )
+    })
+
+    it('should handle no errors in summary', async () => {
+      const files = ['clean.js']
+      const apiKey = 'test-key'
+      const axeLinterUrl = 'https://test-linter.com'
+      const linterConfig = {}
+
+      readFileStub.withArgs('clean.js', 'utf8').returns('const x = 1;')
+
+      nock(axeLinterUrl)
+        .post('/lint-source')
+        .reply(200, {
+          report: {
+            errors: []
+          }
+        })
+
+      const errorCount = await lintFiles(
+        files,
+        apiKey,
+        axeLinterUrl,
+        linterConfig
+      )
+
+      assert.equal(errorCount, 0, 'Should return zero errors')
+      assert.isTrue(
+        summaryStub.addHeading.calledWith('Accessibility Linting Results'),
+        'Should still create summary heading'
+      )
+      assert.isTrue(
+        summaryStub.addRaw.calledWith('Found 0 accessibility issues'),
+        'Should show zero issues in summary'
+      )
+      assert.isFalse(
+        errorStub.called,
+        'Should not create any error annotations'
+      )
     })
   })
 })

--- a/src/linter.test.ts
+++ b/src/linter.test.ts
@@ -493,7 +493,7 @@ describe('linter', () => {
       )
       assert.isTrue(
         errorStub.calledWith(
-          'click-handler - Click handler should have keyboard equivalent',
+          'app.js:1 - click-handler - Click handler should have keyboard equivalent',
           {
             file: 'app.js',
             startLine: 1,

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -72,13 +72,15 @@ export async function lintFiles(
     if (errors.length > 0) {
       // Add file heading
       core.summary
-        .addHeading(`Errors in ${file}:`, 3)
+        .addHeading(`Error${pluralize(errors.length)} in ${file}:`, 2)
+        .addRaw('<span style="color: red">', true)
         .addList(
           errors.map(
             (error) =>
               `Line ${error.line}: ${error.ruleId} - ${error.description}`
           )
         )
+        .addRaw('</span>', true)
         .addBreak()
 
       // Create GitHub annotations

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -83,13 +83,16 @@ export async function lintFiles(
 
       // Create GitHub annotations
       for (const error of errors) {
-        core.error(`${error.ruleId} - ${error.description}`, {
-          file,
-          startLine: error.line,
-          startColumn: error.column,
-          endColumn: error.endColumn,
-          title: 'Axe Linter'
-        })
+        core.error(
+          `${file}:${error.line} - ${error.ruleId} - ${error.description}`,
+          {
+            file,
+            startLine: error.line,
+            startColumn: error.column,
+            endColumn: error.endColumn,
+            title: 'Axe Linter'
+          }
+        )
       }
     }
   }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -72,15 +72,13 @@ export async function lintFiles(
     if (errors.length > 0) {
       // Add file heading
       core.summary
-        .addHeading(`Error${pluralize(errors.length)} in ${file}:`, 2)
-        .addRaw('<span style="color: red">', true)
+        .addHeading(`❌ Error${pluralize(errors.length)} in ${file}:`, 2)
         .addList(
           errors.map(
             (error) =>
-              `Line ${error.line}: ${error.ruleId} - ${error.description}`
+              `🔴 Line ${error.line}: ${error.ruleId} - ${error.description}`
           )
         )
-        .addRaw('</span>', true)
         .addBreak()
 
       // Create GitHub annotations

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import { readFileSync } from 'fs'
-import type { LinterResponse } from './types'
+import type { LinterResponse, ErrorDetail } from './types'
 import fetch from 'node-fetch'
 import { pluralize } from './utils'
 
@@ -11,6 +11,7 @@ export async function lintFiles(
   linterConfig: Record<string, unknown>
 ): Promise<number> {
   let totalErrors = 0
+  const fileErrors: Record<string, ErrorDetail[]> = {}
 
   for (const file of files) {
     const fileContents = readFileSync(file, 'utf8')
@@ -52,18 +53,52 @@ export async function lintFiles(
 
     const errors = result.report.errors
     totalErrors += errors.length
-
-    // Report errors using GitHub annotations
-    for (const error of errors) {
-      core.error(`${error.ruleId} - ${error.description}`, {
-        file,
-        startLine: error.lineNumber,
-        startColumn: error.column,
+    if (errors.length > 0) {
+      fileErrors[file] = errors.map((error) => ({
+        line: error.lineNumber,
+        column: error.column,
         endColumn: error.endColumn,
-        title: 'Axe Linter'
-      })
+        message: `${error.ruleId} - ${error.description}`,
+        ruleId: error.ruleId,
+        description: error.description
+      }))
     }
   }
+
+  // Create summary of all errors
+  core.summary.addHeading('Accessibility Linting Results').addBreak()
+
+  for (const [file, errors] of Object.entries(fileErrors)) {
+    if (errors.length > 0) {
+      // Add file heading
+      core.summary
+        .addHeading(`Errors in ${file}:`, 3)
+        .addList(
+          errors.map(
+            (error) =>
+              `Line ${error.line}: ${error.ruleId} - ${error.description}`
+          )
+        )
+        .addBreak()
+
+      // Create GitHub annotations
+      for (const error of errors) {
+        core.error(`${error.ruleId} - ${error.description}`, {
+          file,
+          startLine: error.line,
+          startColumn: error.column,
+          endColumn: error.endColumn,
+          title: 'Axe Linter'
+        })
+      }
+    }
+  }
+
+  // Add summary footer
+  await core.summary
+    .addBreak()
+    .addRaw(`Found ${totalErrors} accessibility issue${pluralize(totalErrors)}`)
+    .write()
 
   core.debug(`Found ${totalErrors} error${pluralize(totalErrors)}`)
   return totalErrors

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,15 @@ export type Core = Pick<
   'getInput' | 'setOutput' | 'info' | 'setFailed' | 'debug'
 >
 
+export interface ErrorDetail {
+  line: number
+  message: string
+  column: number
+  endColumn: number
+  ruleId: string
+  description: string
+}
+
 export interface LinterError {
   ruleId: string
   lineNumber: number


### PR DESCRIPTION
This PR adds a summary to the job 
ex:
![image](https://github.com/user-attachments/assets/71b7d80e-5813-4e34-8ab1-46261b49c899)

qa notes: make sure that a summary exist similar to the screenshot above when errors are found