### PR TITLE
feat: use pagination to get all files in pull request

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -26,7 +26,10 @@ describe('git', () => {
         pulls: {
           listFiles: sandbox.stub()
         }
-      }
+      },
+      paginate: sandbox
+        .stub()
+        .callsFake(async (fn, options, callback) => callback(await fn(options)))
     }
 
     // Mock GitHub context
@@ -73,7 +76,8 @@ describe('git', () => {
         mockOctokit.rest.pulls.listFiles.calledWith({
           owner: 'test-owner',
           repo: 'test-repo',
-          pull_number: 123
+          pull_number: 123,
+          per_page: 100
         }),
         'listFiles should be called with correct parameters'
       )
@@ -114,7 +118,8 @@ describe('git', () => {
           owner: 'test-owner',
           repo: 'test-repo',
           base: 'old-sha',
-          head: 'new-sha'
+          head: 'new-sha',
+          per_page: 100
         }),
         'compareCommits should be called with correct parameters'
       )

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -118,8 +118,7 @@ describe('git', () => {
           owner: 'test-owner',
           repo: 'test-repo',
           base: 'old-sha',
-          head: 'new-sha',
-          per_page: 100
+          head: 'new-sha'
         }),
         'compareCommits should be called with correct parameters'
       )

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,5 @@
-import * as github from '@actions/github'
 import * as core from '@actions/core'
+import * as github from '@actions/github'
 import { minimatch } from 'minimatch'
 
 const FILE_PATTERNS = [
@@ -37,17 +37,14 @@ export async function getChangedFiles(token: string): Promise<string[]> {
     const base = context.payload.before
     const head = context.payload.after
 
-    return octokit.paginate(
-      octokit.rest.repos.compareCommits,
-      {
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        base,
-        head,
-        per_page: PAGE_SIZE
-      },
-      (response) => filterFiles(response.data.files || [])
-    )
+    const response = await octokit.rest.repos.compareCommits({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      base,
+      head
+    })
+
+    return filterFiles(response.data.files ?? [])
   }
 
   return octokit.paginate(


### PR DESCRIPTION
Adds pagination to gather all files from pull requests and commit comparisons. Currently, the action only checks the first 30, which is the default value of the `per_page` query parameter.

Resolves #66