### PR TITLE
ci(dependabot): use cooldown delay recent updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This applies the new [cooldown option](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) for dependabot. It will hold updates until after they have been out for at least a week. This will allow a reasonable time for packages to exist and if any issues exist in the supply chain, get caught before the updates come through.

No QA Needed
Refs: https://github.com/dequelabs/axe-api-team/issues/598