### PR TITLE
docs: add permissions section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .nyc_output
+.idea

--- a/README.md
+++ b/README.md
@@ -28,7 +28,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: dequelabs/axe-linter-action@v1
+        with:
+          api_key: ${{ secrets.AXE_LINTER_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Example Usage for private repository.
+
+Create a file in your repository called `.github/workflows/axe-linter.yml` with the following contents:
+
+```yaml
+name: Lint for accessibility issues
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to read the contents of the pull request
+      pull-requests: read # Required to read the pull request
+    steps:
+      - uses: actions/checkout@v6
       - uses: dequelabs/axe-linter-action@v1
         with:
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}


### PR DESCRIPTION
**Context**

have setup this Github action on ipedis organisation for both 
 - public repository 
 - private repository
  
  On the public repository i was able to setup with the example present on the readme.  For the private repository run was refuse due to a lack of permission.

```
Run dequelabs/axe-linter-action@v1
Error: Resource not accessible by integration - https://docs.github.com/rest/pulls/pulls#list-pull-requests-files
```

when i dig on the project i saw on [git.ts](https://github.com/dequelabs/axe-linter-action/blob/main/src/git.ts) the action require to :
 - read commits
 - read pull requests

No QA Required