### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
@@ -23,8 +23,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .nvmrc
           cache: 'yarn'

--- a/.github/workflows/yml-checker.yml
+++ b/.github/workflows/yml-checker.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .nvmrc
       # This validator doesn't accept globs.

--- a/dist/index.js
+++ b/dist/index.js
@@ -9551,8 +9551,8 @@
         var cIsNsCharOrWhitespace = isNsCharOrWhitespace(c)
         var cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c)
         return (
-          // ns-plain-safe
-          ((inblock // c = flow-in
+          (// ns-plain-safe
+          (inblock // c = flow-in
             ? cIsNsCharOrWhitespace
             : cIsNsCharOrWhitespace &&
               // - c-flow-indicator
@@ -13270,9 +13270,9 @@
 
       function isHexCode(c) {
         return (
-          (0x30 /* 0 */ <= c && c <= 0x39) /* 9 */ ||
-          (0x41 /* A */ <= c && c <= 0x46) /* F */ ||
-          (0x61 /* a */ <= c && c <= 0x66) /* f */
+          (0x30 /* 0 */ <= c && c <= 0x39 /* 9 */) ||
+          (0x41 /* A */ <= c && c <= 0x46 /* F */) ||
+          (0x61 /* a */ <= c && c <= 0x66 /* f */)
         )
       }
 


### PR DESCRIPTION
## Summary

- Pins `actions/checkout` and `actions/setup-node` to exact commit SHAs in all workflow files
- Improves supply chain security by preventing tag-based attacks
- Bumps setup-node from v4 to v6.

## Test plan

- [x] Verify CI workflows pass with pinned action references

No QA Required