### PR TITLE
docs: remove github token from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ jobs:
       - uses: dequelabs/axe-linter-action@v1
         with:
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Example Usage for private repository.
@@ -55,7 +54,6 @@ jobs:
       - uses: dequelabs/axe-linter-action@v1
         with:
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Limitation


### PR DESCRIPTION
Removed github_token from axe-linter-action examples. We don't require this to operate, so we should not encourage the token being passed around more than necessary.

No QA Required