### PR TITLE
chore: remove husky

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -4,4 +4,4 @@
 
 [hook "lint-staged"]
   event = pre-commit
-  command = npx lint-staged
+  command = npx --no-install lint-staged

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,7 @@
+[hook "build"]
+  event = pre-commit
+  command = bin/build.sh
+
+[hook "lint-staged"]
+  event = pre-commit
+  command = npx lint-staged

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,5 +4,3 @@ cd "$(dirname -- "$0")/../."
 yarn build
 
 git add .
-
-lint-staged

--- a/bin/use-tracked-config.sh
+++ b/bin/use-tracked-config.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd "$(dirname -- "$0")/../."
+git config set --local include.path ../.gitconfig

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "ncc build src/index.ts --license licenses.txt",
     "lint": "eslint .",
     "fmt": "prettier --write .",
-    "prepare": "husky",
+    "prepare": "./bin/use-tracked-config.sh",
     "test": "node --experimental-test-module-mocks --experimental-config-file=node.config.json --test --experimental-test-coverage 'src/**/*.test.ts'"
   },
   "dependencies": {
@@ -22,7 +22,6 @@
     "@types/node": "^24",
     "@vercel/ncc": "^0.38.3",
     "eslint": "^9.20.0",
-    "husky": "^9.1.7",
     "lint-staged": "^15.4.3",
     "prettier": "^3.4.2",
     "typescript": "^5.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,11 +762,6 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-husky@^9.1.7:
-  version "9.1.7"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
-  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
-
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"


### PR DESCRIPTION
Remove husky. Replacing it with the new hook in local config system provided by git. It does require one setup script still to make sure the config is wired up, which is fine.


No QA Required
