### PR TITLE
feat: lint all changed files on pull requests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -87262,9 +87262,9 @@ async function getChangedFiles(token) {
       head
     })
     const files = response.data.files
-    if (files && files.length > 300) {
+    if (files && files.length >= 300) {
       warning(
-        'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
+        'This push changed at least 300 files. The GitHub API only returns up to the first 300 files for push events, so some files may not be linted.'
       )
     }
     return (

--- a/dist/index.js
+++ b/dist/index.js
@@ -87261,20 +87261,27 @@ async function getChangedFiles(token) {
       base,
       head
     })
+    const files = response.data.files
+    if (files && files.length >= 300) {
+      warning(
+        'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
+      )
+    }
     return (
-      response.data.files
+      files
         ?.filter(
           (file) => file.status !== 'removed' && isSupportedFile(file.filename)
         )
         .map((file) => file.filename) || []
     )
   }
-  const response = await octokit.rest.pulls.listFiles({
+  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: context.payload.pull_request.number
+    pull_number: context.payload.pull_request.number,
+    per_page: 100
   })
-  return response.data
+  return files
     .filter(
       (file) => file.status !== 'removed' && isSupportedFile(file.filename)
     )

--- a/dist/index.js
+++ b/dist/index.js
@@ -87262,7 +87262,7 @@ async function getChangedFiles(token) {
       head
     })
     const files = response.data.files
-    if (files && files.length >= 300) {
+    if (files && files.length > 300) {
       warning(
         'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
       )

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -8,13 +8,16 @@ describe('git', () => {
   let mockContext: any
   let githubStub: any
   let debugStub: any
+  let warningStub: any
   let getChangedFiles: typeof import('./git.ts').getChangedFiles
 
   before(async () => {
     debugStub = mock.fn()
+    warningStub = mock.fn()
     githubStub = mock.fn()
 
     mockOctokit = {
+      paginate: mock.fn(() => Promise.resolve([])),
       rest: {
         repos: {
           compareCommits: mock.fn(() =>
@@ -38,7 +41,7 @@ describe('git', () => {
     githubStub.mock.mockImplementation(() => mockOctokit)
 
     mock.module('@actions/core', {
-      namedExports: { debug: debugStub }
+      namedExports: { debug: debugStub, warning: warningStub }
     })
 
     mock.module('@actions/github', {
@@ -54,9 +57,12 @@ describe('git', () => {
 
   beforeEach(() => {
     debugStub.mock.resetCalls()
+    warningStub.mock.resetCalls()
     githubStub.mock.resetCalls()
     githubStub.mock.mockImplementation(() => mockOctokit)
 
+    mockOctokit.paginate.mock.resetCalls()
+    mockOctokit.paginate.mock.mockImplementation(() => Promise.resolve([]))
     mockOctokit.rest.repos.compareCommits.mock.resetCalls()
     mockOctokit.rest.repos.compareCommits.mock.mockImplementation(() =>
       Promise.resolve({ data: { files: [] } })
@@ -84,8 +90,8 @@ describe('git', () => {
         { filename: 'test.tsx' }
       ]
 
-      mockOctokit.rest.pulls.listFiles.mock.mockImplementation(() =>
-        Promise.resolve({ data: mockFiles })
+      mockOctokit.paginate.mock.mockImplementation(() =>
+        Promise.resolve(mockFiles)
       )
 
       const result = await getChangedFiles(token)
@@ -95,12 +101,13 @@ describe('git', () => {
         'getOctokit should be called with correct token'
       )
       assert.ok(
-        wasCalledWith(mockOctokit.rest.pulls.listFiles, {
+        wasCalledWith(mockOctokit.paginate, mockOctokit.rest.pulls.listFiles, {
           owner: 'test-owner',
           repo: 'test-repo',
-          pull_number: 123
+          pull_number: 123,
+          per_page: 100
         }),
-        'listFiles should be called with correct parameters'
+        'paginate should be called with listFiles and correct parameters'
       )
 
       assert.deepEqual(
@@ -155,9 +162,7 @@ describe('git', () => {
     it('should handle empty file lists', async () => {
       mockContext.payload.pull_request = { number: 123 }
 
-      mockOctokit.rest.pulls.listFiles.mock.mockImplementation(() =>
-        Promise.resolve({ data: [] })
-      )
+      mockOctokit.paginate.mock.mockImplementation(() => Promise.resolve([]))
 
       const result = await getChangedFiles(token)
 
@@ -188,8 +193,8 @@ describe('git', () => {
         { filename: 'test.rb' }
       ]
 
-      mockOctokit.rest.pulls.listFiles.mock.mockImplementation(() =>
-        Promise.resolve({ data: mockFiles })
+      mockOctokit.paginate.mock.mockImplementation(() =>
+        Promise.resolve(mockFiles)
       )
 
       const result = await getChangedFiles(token)
@@ -202,9 +207,7 @@ describe('git', () => {
       mockContext.payload.pull_request = { number: 123 }
 
       const error = new Error('API Error')
-      mockOctokit.rest.pulls.listFiles.mock.mockImplementation(() =>
-        Promise.reject(error)
-      )
+      mockOctokit.paginate.mock.mockImplementation(() => Promise.reject(error))
 
       try {
         await getChangedFiles(token)
@@ -225,8 +228,8 @@ describe('git', () => {
         { filename: 'test.tsx', status: 'added' }
       ]
 
-      mockOctokit.rest.pulls.listFiles.mock.mockImplementation(() =>
-        Promise.resolve({ data: mockFiles })
+      mockOctokit.paginate.mock.mockImplementation(() =>
+        Promise.resolve(mockFiles)
       )
 
       const result = await getChangedFiles(token)
@@ -272,14 +275,56 @@ describe('git', () => {
         { filename: 'test5.js', status: 'changed' }
       ]
 
-      mockOctokit.rest.pulls.listFiles.mock.mockImplementation(() =>
-        Promise.resolve({ data: mockFiles })
+      mockOctokit.paginate.mock.mockImplementation(() =>
+        Promise.resolve(mockFiles)
       )
 
       const result = await getChangedFiles(token)
 
       assert.deepEqual(result, ['test1.js', 'test2.js', 'test3.js', 'test5.js'])
       assert.ok(!result.includes('test4.js'))
+    })
+
+    it('should warn when push returns 300 or more files', async () => {
+      mockContext.payload.before = 'old-sha'
+      mockContext.payload.after = 'new-sha'
+
+      const mockFiles = Array.from({ length: 300 }, (_, i) => ({
+        filename: `file${i}.js`,
+        status: 'added'
+      }))
+
+      mockOctokit.rest.repos.compareCommits.mock.mockImplementation(() =>
+        Promise.resolve({ data: { files: mockFiles } })
+      )
+
+      await getChangedFiles(token)
+
+      assert.strictEqual(warningStub.mock.callCount(), 1)
+      assert.ok(
+        wasCalledWith(
+          warningStub,
+          'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
+        )
+      )
+    })
+
+    it('should not warn when push returns fewer than 300 files', async () => {
+      mockContext.payload.before = 'old-sha'
+      mockContext.payload.after = 'new-sha'
+
+      const mockFiles = Array.from({ length: 299 }, (_, i) => ({
+        filename: `file${i}.js`,
+        status: 'added'
+      }))
+
+      mockOctokit.rest.repos.compareCommits.mock.mockImplementation(() =>
+        Promise.resolve({ data: { files: mockFiles } })
+      )
+
+      await getChangedFiles(token)
+
+      assert.strictEqual(warningStub.mock.callCount(), 0)
     })
   })
   describe('file pattern matching', () => {

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -285,31 +285,7 @@ describe('git', () => {
       assert.ok(!result.includes('test4.js'))
     })
 
-    it('should warn when push returns more than 300 files', async () => {
-      mockContext.payload.before = 'old-sha'
-      mockContext.payload.after = 'new-sha'
-
-      const mockFiles = Array.from({ length: 301 }, (_, i) => ({
-        filename: `file${i}.js`,
-        status: 'added'
-      }))
-
-      mockOctokit.rest.repos.compareCommits.mock.mockImplementation(() =>
-        Promise.resolve({ data: { files: mockFiles } })
-      )
-
-      await getChangedFiles(token)
-
-      assert.strictEqual(warningStub.mock.callCount(), 1)
-      assert.ok(
-        wasCalledWith(
-          warningStub,
-          'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
-        )
-      )
-    })
-
-    it('should not warn when push returns exactly 300 files', async () => {
+    it('should warn when push returns 300 or more files', async () => {
       mockContext.payload.before = 'old-sha'
       mockContext.payload.after = 'new-sha'
 
@@ -324,7 +300,13 @@ describe('git', () => {
 
       await getChangedFiles(token)
 
-      assert.strictEqual(warningStub.mock.callCount(), 0)
+      assert.strictEqual(warningStub.mock.callCount(), 1)
+      assert.ok(
+        wasCalledWith(
+          warningStub,
+          'This push changed at least 300 files. The GitHub API only returns up to the first 300 files for push events, so some files may not be linted.'
+        )
+      )
     })
 
     it('should not warn when push returns fewer than 300 files', async () => {

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -285,11 +285,11 @@ describe('git', () => {
       assert.ok(!result.includes('test4.js'))
     })
 
-    it('should warn when push returns 300 or more files', async () => {
+    it('should warn when push returns more than 300 files', async () => {
       mockContext.payload.before = 'old-sha'
       mockContext.payload.after = 'new-sha'
 
-      const mockFiles = Array.from({ length: 300 }, (_, i) => ({
+      const mockFiles = Array.from({ length: 301 }, (_, i) => ({
         filename: `file${i}.js`,
         status: 'added'
       }))
@@ -307,6 +307,24 @@ describe('git', () => {
           'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
         )
       )
+    })
+
+    it('should not warn when push returns exactly 300 files', async () => {
+      mockContext.payload.before = 'old-sha'
+      mockContext.payload.after = 'new-sha'
+
+      const mockFiles = Array.from({ length: 300 }, (_, i) => ({
+        filename: `file${i}.js`,
+        status: 'added'
+      }))
+
+      mockOctokit.rest.repos.compareCommits.mock.mockImplementation(() =>
+        Promise.resolve({ data: { files: mockFiles } })
+      )
+
+      await getChangedFiles(token)
+
+      assert.strictEqual(warningStub.mock.callCount(), 0)
     })
 
     it('should not warn when push returns fewer than 300 files', async () => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -36,8 +36,16 @@ export async function getChangedFiles(token: string): Promise<string[]> {
       head
     })
 
+    const files = response.data.files
+
+    if (files && files.length >= 300) {
+      core.warning(
+        'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
+      )
+    }
+
     return (
-      response.data.files
+      files
         ?.filter(
           (file) => file.status !== 'removed' && isSupportedFile(file.filename)
         )
@@ -45,13 +53,14 @@ export async function getChangedFiles(token: string): Promise<string[]> {
     )
   }
 
-  const response = await octokit.rest.pulls.listFiles({
+  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: context.payload.pull_request.number
+    pull_number: context.payload.pull_request.number,
+    per_page: 100
   })
 
-  return response.data
+  return files
     .filter(
       (file) => file.status !== 'removed' && isSupportedFile(file.filename)
     )

--- a/src/git.ts
+++ b/src/git.ts
@@ -38,7 +38,7 @@ export async function getChangedFiles(token: string): Promise<string[]> {
 
     const files = response.data.files
 
-    if (files && files.length >= 300) {
+    if (files && files.length > 300) {
       core.warning(
         'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
       )

--- a/src/git.ts
+++ b/src/git.ts
@@ -38,9 +38,9 @@ export async function getChangedFiles(token: string): Promise<string[]> {
 
     const files = response.data.files
 
-    if (files && files.length > 300) {
+    if (files && files.length >= 300) {
       core.warning(
-        'This push includes 300+ changed files. The GitHub API only returns the first 300 files for push events, so some files may not be linted.'
+        'This push changed at least 300 files. The GitHub API only returns up to the first 300 files for push events, so some files may not be linted.'
       )
     }
 


### PR DESCRIPTION
## Summary

- Use `octokit.paginate()` for pull request file listings so all changed files across all pages are linted (previously only the first ~30)
- Emit a `core.warning()` on push events when GitHub's `compareCommits` returns 300 files (the API ceiling), letting users know some files may not be linted

## Why

The PR path called `octokit.rest.pulls.listFiles()` with no pagination parameters, silently capping at ~30 files per PR. The push path uses `compareCommits`, which GitHub hard-caps at 300 files with no pagination support — previously the action gave no indication when this limit was hit.

## Test plan

- [x] Existing tests updated to mock `octokit.paginate` instead of `listFiles` for PR scenarios
- [x] New test: push with 300 files triggers `core.warning()` once with expected message
- [x] New test: push with 299 files does not trigger a warning
- [x] `pnpm test` — all 45 tests pass, 100% line/branch/function coverage on `git.ts`
- [x] `pnpm build` — `dist/index.js` builds cleanly

Fixes: #66 
