### PR TITLE
fix: lower file size limit to 900,000 bytes to match API cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ If there are more errors, they will not be reported. If you would like to view t
 
 Additional information can be found in [this GitHub discussion](https://github.com/orgs/community/discussions/26680).
 
-Individual files larger than 900 MB are skipped and logged as a warning. The axe-linter API has a 1 GB request size cap, so oversized files are filtered out pre-emptively to avoid 413 server request errors.
+Individual files larger than 900,000 bytes are skipped and logged as a warning. The axe-linter API has a 1 MB request size cap, so oversized files are filtered out pre-emptively to avoid 413 server request errors.

--- a/src/linter.test.ts
+++ b/src/linter.test.ts
@@ -262,7 +262,9 @@ describe('linter', () => {
     it('should skip files exceeding the size limit', async () => {
       const files = ['huge.js']
       statSyncMock.mock.mockImplementation((path: string) => {
-        if (path === 'huge.js') return { size: 900 * 1024 * 1024 + 1 }
+        if (path === 'huge.js') {
+          return { size: 900_001 }
+        }
         return { size: 100 }
       })
 
@@ -289,7 +291,7 @@ describe('linter', () => {
       )
       assert.match(
         warningStub.mock.calls[0].arguments[0],
-        /Skipping huge\.js: file size \(\d+ MB\) exceeds 900 MB limit/,
+        /Skipping huge\.js: file size \(\d+ bytes\) exceeds 900000 bytes limit/,
         'should log warning message about the oversized file'
       )
       assert.strictEqual(

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -4,9 +4,7 @@ import { fetch } from 'undici'
 import type { LinterResponse } from './types.ts'
 import { pluralize } from './utils.ts'
 
-const BYTES_PER_MB = 1024 * 1024
-const MAX_FILE_SIZE_BYTES = 900 * BYTES_PER_MB
-const MAX_FILE_SIZE_MB = MAX_FILE_SIZE_BYTES / BYTES_PER_MB
+const MAX_FILE_SIZE_BYTES = 900_000
 
 export async function lintFiles(
   files: string[],
@@ -21,9 +19,8 @@ export async function lintFiles(
 
     // Skip files exceeding the size limit
     if (fileSize > MAX_FILE_SIZE_BYTES) {
-      const sizeMB = Math.round(fileSize / BYTES_PER_MB)
       core.warning(
-        `Skipping ${file}: file size (${sizeMB} MB) exceeds ${MAX_FILE_SIZE_MB} MB limit`
+        `Skipping ${file}: file size (${fileSize} bytes) exceeds ${MAX_FILE_SIZE_BYTES} bytes limit`
       )
       continue
     }


### PR DESCRIPTION
Ref: https://github.com/dequelabs/axe-linter-action/issues/80

qa notes: please see ticket