### PR TITLE
docs: change mentions to v1 in the readme file to v1.3.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: dequelabs/axe-linter-action@v1
+      - uses: dequelabs/axe-linter-action@v1.3.0
         with:
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
       pull-requests: read # Required to read the pull request
     steps:
       - uses: actions/checkout@v6
-      - uses: dequelabs/axe-linter-action@v1
+      - uses: dequelabs/axe-linter-action@v1.3.0
         with:
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The readme currently refers to v1. On top of not being the latest version of the linter action, something has recently changed in GitHub's authentication structure that causes v1 to fail. Having it still mentioned in the readme may mislead consumers into using the old version instead of the latest.  